### PR TITLE
[MOAT - 118] - Add CPack feature to Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.1.0 )
 
-project( date_prj )
+project( date )
 
 include( GNUInstallDirs )
 
@@ -45,6 +45,8 @@ set( HEADER_FILES
 	${HEADER_FOLDER}/date/tz_private.h
 )
 
+add_definitions(-DONLY_C_LOCALE=1)
+
 add_library( tz ${HEADER_FILES} ${SOURCE_FOLDER}/tz.cpp )
 
 if( USE_SYSTEM_TZ_DB )
@@ -76,7 +78,7 @@ if( BUILD_SHARED_LIBS )
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fPIC")
 endif( )
 
-target_link_libraries( tz ${CMAKE_THREAD_LIBS_INIT} ${OPTIONAL_LIBRARIES} )
+target_link_libraries( tz ${CMAKE_THREAD_LIBS_INIT} ${CURL_LIBRARIES} ${OPTIONAL_LIBRARIES} )
 
 # add include folders to the library and targets that consume it
 target_include_directories(tz PUBLIC
@@ -173,3 +175,31 @@ if ( ENABLE_DATE_TESTING )
         endif( )
     endforeach( )
 endif( )
+
+######################
+##CPack Debian Build##
+######################
+
+# Setting Patch Version
+SET(MAJOR_VERSION "0")
+SET(MINOR_VERSION "0")
+SET(PATCH_VERSION "1")
+
+# Setting the install directory. By default it is installed in usr/local/
+SET(CPACK_INSTALL_PREFIX "/usr") 
+SET(CPACK_SET_DESTDIR "on")
+# Debian package
+SET(CPACK_GENERATOR "DEB")
+SET(CPACK_PACKAGE_DESCRIPTION "Date library for Mission Control - MOAT")
+SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A library for time zone conversions and date manipulations.")
+SET(CPACK_PACKAGE_VENDOR "Bossa Nova Robotics")
+SET(CPACK_PACKAGE_CONTACT "akshay.prasad@bossanova.com")
+SET(CPACK_PACKAGE_VERSION_MAJOR "${MAJOR_VERSION}")
+SET(CPACK_PACKAGE_VERSION_MINOR "${MINOR_VERSION}")
+SET(CPACK_PACKAGE_VERSION_PATCH "${PATCH_VERSION}")
+SET(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${MAJOR_VERSION}.${MINOR_VERSION}.${CPACK_PACKAGE_VERSION_PATCH}")
+SET(CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${MAJOR_VERSION}.${MINOR_VERSION}.${CPACK_PACKAGE_VERSION_PATCH}")
+
+SET(CPACK_DEBIAN_ARCHITECTURE ${CMAKE_SYSTEM_PROCESSOR})
+
+INCLUDE(CPack)

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+## Short script to build and pack the library into a debian.
+## It will also invoke an installation for the library
+if [ ! -d "build" ]; then
+	mkdir build
+fi
+cd build
+cmake ..
+OUTPUT=$(cpack .. | tail -1)
+echo "The package was created in the build directory and is named : $OUTPUT"
+echo "You may use sudo dpkg -i <package name> to install the package"


### PR DESCRIPTION
# Description

What does this PR do?
1. This PR adds some `CPack` functionality to build and package the library into a `Debian` package which can then be shared.
2. This was necessary because the library and especially the tests use some of the more modern C++14 and C++17 features which might not be available.
3. It also uses a more modern variant of `CMake`

## Testing

How did you test it? Did you add automated (unit, sim, integration) tests where possible?
1. Installed the debian package.
2. Ran the test suite with the install package binaries linked.
3. Tests passed.
